### PR TITLE
Add support for personalized mixes in spotdl

### DIFF
--- a/spotdl/utils/spotify.py
+++ b/spotdl/utils/spotify.py
@@ -203,6 +203,20 @@ class SpotifyClient(Spotify, metaclass=Singleton):
 
         return response
 
+    def get_personalized_playlists(self):
+        """
+        Get personalized playlists for the user.
+
+        ### Returns
+        - A list of personalized playlists.
+        """
+
+        if not self.user_auth:
+            raise SpotifyError("User authentication is required to get personalized playlists.")
+
+        response = self._get("me/personalized-playlists")
+        return response.get("items", [])
+
 
 def save_spotify_cache(cache: Dict[str, Optional[Dict]]):
     """


### PR DESCRIPTION
Add support for retrieving personalized playlists from Spotify.

* Add `get_personalized_playlists` method to `SpotifyClient` class to retrieve personalized playlists for the user.
* Raise `SpotifyError` if user authentication is not available.
* Use `_get` method to fetch personalized playlists from the Spotify API.
* Return a list of personalized playlists.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Ok2dot0/spotify-downloader/pull/1?shareId=609e14e5-29bc-4691-b6f2-edc0d8eb06ec).